### PR TITLE
Refactor DataTable actions into ZardUI dropdown menu

### DIFF
--- a/frontend/src/app/features/customers/customer-list/customer-list.component.html
+++ b/frontend/src/app/features/customers/customer-list/customer-list.component.html
@@ -43,6 +43,7 @@
         [columns]="columns()"
         [data]="customers()"
         [isLoading]="isLoading()"
+        [actions]="actions()"
         (sortChange)="onSortChange($event)"
       />
     </div>
@@ -82,26 +83,6 @@
 
 <ng-template #telephoneTemplate let-row>
   <span>{{ row.telephone || '—' }}</span>
-</ng-template>
-
-<ng-template #actionsTemplate let-row>
-  <div class="flex items-center gap-1.5">
-    <a [routerLink]="['/customers', row.id]">
-      <z-button zType="default" zSize="sm">View</z-button>
-    </a>
-    <a [routerLink]="['/customers', row.id, 'edit']">
-      <z-button zType="warning" zSize="sm">Edit</z-button>
-    </a>
-    <z-button [zType]="row.active ? 'secondary' : 'ghost'" zSize="sm" (click)="onToggleActive(row)">
-      {{ row.active ? 'Disable' : 'Enable' }}
-    </z-button>
-    @if (isSuperuser()) {
-      <z-button zType="destructive" zSize="sm" (click)="onDelete(row)">Delete</z-button>
-    }
-    <a [routerLink]="['/customers', row.id, 'applications', 'new']">
-      <z-button zType="success" zSize="sm">New Application</z-button>
-    </a>
-  </div>
 </ng-template>
 
 <app-bulk-delete-dialog

--- a/frontend/src/app/shared/components/data-table/data-table.component.html
+++ b/frontend/src/app/shared/components/data-table/data-table.component.html
@@ -62,6 +62,34 @@
                       context: { $implicit: row, value: getRawValue(row, column.key), row: row }
                     "
                   />
+                } @else if (column.key === 'actions' && actions()?.length) {
+                  <div class="flex items-center justify-end">
+                    <button
+                      z-dropdown
+                      [zDropdownMenu]="rowActionsMenu"
+                      z-button
+                      zType="ghost"
+                      zSize="sm"
+                      type="button"
+                      class="h-8 w-8 p-0"
+                      (click.stop)
+                    >
+                      <z-icon zType="ellipsis" class="rotate-90" />
+                    </button>
+                    <z-dropdown-menu-content #rowActionsMenu class="z-50 min-w-[12rem]">
+                      @for (action of actions() ?? []; track action.label) {
+                        <button
+                          z-dropdown-menu-item
+                          type="button"
+                          [variant]="action.isDestructive ? 'destructive' : 'default'"
+                          (click)="onActionSelect(action, row, $event)"
+                        >
+                          <z-icon [zType]="action.icon" class="mr-2" />
+                          {{ action.label }}
+                        </button>
+                      }
+                    </z-dropdown-menu-content>
+                  </div>
                 } @else {
                   {{ getCellValue(row, column.key) }}
                 }

--- a/frontend/src/app/shared/components/data-table/data-table.component.ts
+++ b/frontend/src/app/shared/components/data-table/data-table.component.ts
@@ -11,6 +11,9 @@ import {
 import { FormsModule } from '@angular/forms';
 
 import { ZardCheckboxComponent } from '@/shared/components/checkbox';
+import { ZardButtonComponent } from '@/shared/components/button';
+import { ZardDropdownImports } from '@/shared/components/dropdown/dropdown.imports';
+import { ZardIconComponent, type ZardIcon } from '@/shared/components/icon';
 import { ZardSkeletonComponent } from '@/shared/components/skeleton';
 import { ZardTableImports } from '@/shared/components/table';
 
@@ -28,6 +31,13 @@ export interface PageEvent {
   pageSize: number;
 }
 
+export interface DataTableAction<T = any> {
+  label: string;
+  icon: ZardIcon;
+  action: (item: T) => void;
+  isDestructive?: boolean;
+}
+
 export interface SortEvent {
   column: string;
   direction: 'asc' | 'desc';
@@ -39,6 +49,9 @@ export interface SortEvent {
   imports: [
     CommonModule,
     FormsModule,
+    ZardButtonComponent,
+    ZardIconComponent,
+    ...ZardDropdownImports,
     ...ZardTableImports,
     ZardSkeletonComponent,
     ZardCheckboxComponent,
@@ -50,6 +63,7 @@ export interface SortEvent {
 export class DataTableComponent<T = Record<string, any>> {
   data = input.required<readonly T[]>();
   columns = input.required<readonly ColumnConfig<T>[]>();
+  actions = input<readonly DataTableAction<T>[] | null>(null);
   totalItems = input<number>(0);
   isLoading = input<boolean>(false);
   skeletonRows = input<number>(10);
@@ -80,5 +94,10 @@ export class DataTableComponent<T = Record<string, any>> {
 
   getRawValue(row: T, key: string): unknown {
     return (row as Record<string, unknown>)[key];
+  }
+
+  onActionSelect(action: DataTableAction<T>, row: T, event?: Event): void {
+    event?.stopPropagation();
+    action.action(row);
   }
 }


### PR DESCRIPTION
### Motivation
- Replace repeated per-row action buttons with a compact, consistent three-dot context menu to improve UI clarity and reduce duplicated markup.
- Provide a reusable action interface so other lists using `DataTable` can adopt the dropdown without copying button layouts.
- Preserve backward compatibility with existing column templates while enabling a dynamic `actions` configuration.

### Description
- Add a reusable `DataTableAction` interface and new `actions` input on `DataTableComponent` as `actions: input<readonly DataTableAction<T>[] | null>(null)` to accept structured actions of the form `{ label, icon, action, isDestructive? }`.
- Integrate ZardUI dropdown pieces into the data table by importing `ZardDropdownImports`, `ZardButtonComponent` and `ZardIconComponent`, and rendering a single icon-only `z-button` trigger with an `ellipsis` icon and `z-dropdown` directive for the row actions cell.
- Implement the dropdown menu template in `data-table.component.html` to map passed `actions` into menu items, map `isDestructive` to the destructive variant, and call `onActionSelect(action, row)` which `stopPropagation()` before invoking the action to avoid triggering row selection.
- Migrate `CustomerListComponent` to populate the new `actions` computed property (View Detail, Edit, Toggle Active, New Application, and conditional Delete) and pass it to the table via `[actions]=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986cb0ee2f8832994c28d9e46a276f8)