### PR TITLE
Enhance list navigation, pagination counts, document previews, and delete flow

### DIFF
--- a/frontend/src/app/features/applications/application-detail/application-detail.component.html
+++ b/frontend/src/app/features/applications/application-detail/application-detail.component.html
@@ -314,13 +314,11 @@
       }
     </z-card>
 
-    <z-card class="p-6">
-      <div class="flex items-center justify-between mb-4">
-        <h3 class="text-lg font-semibold">Optional Documents</h3>
-      </div>
-      @if (optionalDocuments().length === 0) {
-        <div class="text-sm text-muted-foreground">No optional documents pending.</div>
-      } @else {
+    @if (optionalDocuments().length > 0) {
+      <z-card class="p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-lg font-semibold">Optional Documents</h3>
+        </div>
         <div class="overflow-x-auto">
           <table class="w-full border-collapse">
             <thead>
@@ -343,8 +341,8 @@
             </tbody>
           </table>
         </div>
-      }
-    </z-card>
+      </z-card>
+    }
   </div>
 }
 
@@ -366,6 +364,8 @@
           [fileName]="selectedFile()?.name || selectedDocument()!.fileLink || null"
           [progress]="uploadProgress()"
           [disabled]="isSaving()"
+          [previewUrl]="inlinePreviewUrl()"
+          [previewType]="inlinePreviewType()"
           (fileSelected)="onFileSelected($event)"
           (cleared)="onFileCleared()"
         />
@@ -429,6 +429,7 @@
               zType="outline"
               zSize="sm"
               label="Preview"
+              previewSize="md"
               (viewFull)="viewDocument(selectedDocument()!)"
             />
             @if (selectedDocument()!.docType.hasOcrCheck) {

--- a/frontend/src/app/features/applications/application-list/application-list.component.html
+++ b/frontend/src/app/features/applications/application-list/application-list.component.html
@@ -61,6 +61,18 @@
             }
           }
         </ng-template>
+        <ng-template #columnCreatedAt let-row>
+          <div class="flex flex-col">
+            <span class="text-sm">{{
+              $any(row).createdAt ? ($any(row).createdAt | date: 'dd MMM yyyy HH:mm:ss') : ''
+            }}</span>
+            @if ($any(row).updatedAt && $any(row).updatedAt !== $any(row).createdAt) {
+              <span class="text-xs text-muted-foreground">{{
+                $any(row).updatedAt ? ($any(row).updatedAt | date: 'dd MMM yyyy HH:mm:ss') : ''
+              }}</span>
+            }
+          </div>
+        </ng-template>
       </app-data-table>
     </div>
 
@@ -68,6 +80,7 @@
       <app-pagination-controls
         [page]="page()"
         [totalPages]="totalPages()"
+        [totalItems]="totalItems()"
         (pageChange)="onPageChange($event)"
       />
     </div>
@@ -83,6 +96,13 @@
   cancelText="Cancel"
   (confirmed)="confirmDeleteAction()"
   (cancelled)="cancelDeleteAction()"
+/>
+
+<app-application-delete-dialog
+  [isOpen]="deleteWithInvoiceOpen()"
+  [data]="deleteWithInvoiceData()"
+  (confirmed)="confirmDeleteWithInvoiceAction()"
+  (cancelled)="cancelDeleteWithInvoiceAction()"
 />
 
 <app-bulk-delete-dialog

--- a/frontend/src/app/features/customers/customer-list/customer-list.component.html
+++ b/frontend/src/app/features/customers/customer-list/customer-list.component.html
@@ -1,7 +1,7 @@
 <div class="h-full flex flex-col gap-6">
   <div class="flex justify-between items-center">
     <h1 class="text-3xl font-bold tracking-tight">Customer List</h1>
-    <a routerLink="/customers/new">
+    <a routerLink="/customers/new" [state]="{ from: 'customers', searchQuery: query() }">
       <z-button zType="default" zSize="default"> New Customer </z-button>
     </a>
   </div>
@@ -48,6 +48,7 @@
       <app-pagination-controls
         [page]="page()"
         [totalPages]="totalPages()"
+        [totalItems]="totalItems()"
         (pageChange)="onPageChange($event)"
       />
     </div>

--- a/frontend/src/app/features/customers/customer-list/customer-list.component.ts
+++ b/frontend/src/app/features/customers/customer-list/customer-list.component.ts
@@ -229,7 +229,9 @@ export class CustomerListComponent implements OnInit {
     // Shift+N for New Customer
     if (event.key === 'N' && !event.ctrlKey && !event.altKey && !event.metaKey) {
       event.preventDefault();
-      this.router.navigate(['/customers', 'new']);
+      this.router.navigate(['/customers', 'new'], {
+        state: { from: 'customers', searchQuery: this.query() },
+      });
     }
   }
 

--- a/frontend/src/app/features/invoices/invoice-detail/invoice-detail.component.ts
+++ b/frontend/src/app/features/invoices/invoice-detail/invoice-detail.component.ts
@@ -64,6 +64,7 @@ export class InvoiceDetailComponent implements OnInit {
 
   readonly invoice = signal<InvoiceDetail | null>(null);
   readonly isLoading = signal(false);
+  readonly originSearchQuery = signal<string | null>(null);
   readonly paymentModalOpen = signal(false);
   readonly selectedApplication = signal<InvoiceApplicationDetail | null>(null);
   readonly selectedPayment = signal<Payment | null>(null);
@@ -99,7 +100,9 @@ export class InvoiceDetailComponent implements OnInit {
     // E --> Edit
     if (event.key === 'E' && !event.ctrlKey && !event.altKey && !event.metaKey) {
       event.preventDefault();
-      this.router.navigate(['/invoices', invoice.id, 'edit']);
+      this.router.navigate(['/invoices', invoice.id, 'edit'], {
+        state: { from: 'invoices', focusId: invoice.id, searchQuery: this.originSearchQuery() },
+      });
     }
 
     // B or Left Arrow --> Back to list
@@ -110,7 +113,13 @@ export class InvoiceDetailComponent implements OnInit {
       !event.metaKey
     ) {
       event.preventDefault();
-      this.router.navigate(['/invoices']);
+      this.router.navigate(['/invoices'], {
+        state: {
+          focusTable: true,
+          focusId: invoice.id,
+          searchQuery: this.originSearchQuery(),
+        },
+      });
     }
   }
 
@@ -143,6 +152,8 @@ export class InvoiceDetailComponent implements OnInit {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
+    const st = (window as any).history.state || {};
+    this.originSearchQuery.set(st.searchQuery ?? null);
 
     const idParam = this.route.snapshot.paramMap.get('id');
     if (idParam) {

--- a/frontend/src/app/features/invoices/invoice-form/invoice-form.component.ts
+++ b/frontend/src/app/features/invoices/invoice-form/invoice-form.component.ts
@@ -141,7 +141,20 @@ export class InvoiceFormComponent implements OnInit {
   }
 
   goBack(): void {
-    this.router.navigate(['/invoices']);
+    const nav = this.router.getCurrentNavigation();
+    const st = (nav && nav.extras && (nav.extras.state as any)) || (history.state as any);
+
+    const focusState: Record<string, unknown> = { focusTable: true };
+    if (st?.focusId) {
+      focusState['focusId'] = st.focusId;
+    } else if (this.invoice()?.id) {
+      focusState['focusId'] = this.invoice()?.id;
+    }
+    if (st?.searchQuery) {
+      focusState['searchQuery'] = st.searchQuery;
+    }
+
+    this.router.navigate(['/invoices'], { state: focusState });
   }
 
   ngOnInit(): void {

--- a/frontend/src/app/features/invoices/invoice-list/invoice-list.component.html
+++ b/frontend/src/app/features/invoices/invoice-list/invoice-list.component.html
@@ -5,7 +5,7 @@
       <a routerLink="/invoices/import">
         <z-button zType="secondary" zSize="default">Import Invoice</z-button>
       </a>
-      <a routerLink="/invoices/new">
+      <a routerLink="/invoices/new" [state]="{ from: 'invoices', searchQuery: query() }">
         <z-button zType="default" zSize="default">New Invoice</z-button>
       </a>
     </div>
@@ -62,6 +62,7 @@
       <app-pagination-controls
         [page]="page()"
         [totalPages]="totalPages()"
+        [totalItems]="totalItems()"
         (pageChange)="onPageChange($event)"
       />
     </div>
@@ -69,7 +70,11 @@
 </div>
 
 <ng-template #numberTemplate let-row>
-  <a [routerLink]="['/invoices', row.id]" class="font-medium hover:underline">
+  <a
+    [routerLink]="['/invoices', row.id]"
+    [state]="{ from: 'invoices', focusId: row.id, searchQuery: query() }"
+    class="font-medium hover:underline"
+  >
     {{ row.invoiceNoDisplay || row.invoiceNo || '—' }}
   </a>
 </ng-template>
@@ -115,6 +120,19 @@
       <span>Paid: {{ formatCurrency(row.totalPaidAmount) }}</span>
       <span>Due: {{ formatCurrency(row.totalDueAmount) }}</span>
     </ng-template>
+  </div>
+</ng-template>
+
+<ng-template #createdAtTemplate let-row>
+  <div class="flex flex-col">
+    <span class="text-sm">{{
+      $any(row).createdAt ? ($any(row).createdAt | date: 'dd MMM yyyy HH:mm:ss') : ''
+    }}</span>
+    @if ($any(row).updatedAt && $any(row).updatedAt !== $any(row).createdAt) {
+      <span class="text-xs text-muted-foreground">{{
+        $any(row).updatedAt ? ($any(row).updatedAt | date: 'dd MMM yyyy HH:mm:ss') : ''
+      }}</span>
+    }
   </div>
 </ng-template>
 

--- a/frontend/src/app/features/products/product-detail/product-detail.component.ts
+++ b/frontend/src/app/features/products/product-detail/product-detail.component.ts
@@ -65,6 +65,7 @@ export class ProductDetailComponent implements OnInit {
 
   readonly product = signal<ProductDetail | null>(null);
   readonly isLoading = signal(false);
+  readonly originSearchQuery = signal<string | null>(null);
 
   readonly requiredDocuments = computed<DocumentType[]>(
     () => this.product()?.requiredDocumentTypes ?? [],
@@ -102,7 +103,9 @@ export class ProductDetailComponent implements OnInit {
     // E --> Edit
     if (event.key === 'E' && !event.ctrlKey && !event.altKey && !event.metaKey) {
       event.preventDefault();
-      this.router.navigate(['/products', product.id, 'edit']);
+      this.router.navigate(['/products', product.id, 'edit'], {
+        state: { from: 'products', focusId: product.id, searchQuery: this.originSearchQuery() },
+      });
     }
 
     // B or Left Arrow --> Back to list
@@ -113,7 +116,13 @@ export class ProductDetailComponent implements OnInit {
       !event.metaKey
     ) {
       event.preventDefault();
-      this.router.navigate(['/products']);
+      this.router.navigate(['/products'], {
+        state: {
+          focusTable: true,
+          focusId: product.id,
+          searchQuery: this.originSearchQuery(),
+        },
+      });
     }
   }
 
@@ -121,6 +130,8 @@ export class ProductDetailComponent implements OnInit {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
+    const st = (window as any).history.state || {};
+    this.originSearchQuery.set(st.searchQuery ?? null);
     const idParam = this.route.snapshot.paramMap.get('id');
     if (!idParam) {
       return;

--- a/frontend/src/app/features/products/product-form/product-form.component.ts
+++ b/frontend/src/app/features/products/product-form/product-form.component.ts
@@ -201,7 +201,20 @@ export class ProductFormComponent implements OnInit {
   }
 
   goBack(): void {
-    this.router.navigate(['/products']);
+    const nav = this.router.getCurrentNavigation();
+    const st = (nav && nav.extras && (nav.extras.state as any)) || (history.state as any);
+
+    const focusState: Record<string, unknown> = { focusTable: true };
+    if (st?.focusId) {
+      focusState['focusId'] = st.focusId;
+    } else if (this.product()?.id) {
+      focusState['focusId'] = this.product()?.id;
+    }
+    if (st?.searchQuery) {
+      focusState['searchQuery'] = st.searchQuery;
+    }
+
+    this.router.navigate(['/products'], { state: focusState });
   }
 
   toggleLastStep(index: number): void {

--- a/frontend/src/app/features/products/product-list/product-list.component.html
+++ b/frontend/src/app/features/products/product-list/product-list.component.html
@@ -1,7 +1,7 @@
 <div class="h-full flex flex-col gap-6">
   <div class="flex flex-wrap items-center justify-between gap-3">
     <h1 class="text-3xl font-bold tracking-tight">Products</h1>
-    <a routerLink="/products/new">
+    <a routerLink="/products/new" [state]="{ from: 'products', searchQuery: query() }">
       <z-button zType="default" zSize="default">New Product</z-button>
     </a>
   </div>
@@ -40,6 +40,7 @@
       <app-pagination-controls
         [page]="page()"
         [totalPages]="totalPages()"
+        [totalItems]="totalItems()"
         (pageChange)="onPageChange($event)"
       />
     </div>
@@ -47,7 +48,11 @@
 </div>
 
 <ng-template #nameTemplate let-row>
-  <a [routerLink]="['/products', row.id]" class="font-medium hover:underline">
+  <a
+    [routerLink]="['/products', row.id]"
+    [state]="{ from: 'products', focusId: row.id, searchQuery: query() }"
+    class="font-medium hover:underline"
+  >
     {{ row.name }}
   </a>
 </ng-template>
@@ -75,6 +80,19 @@
 
 <ng-template #priceTemplate let-row>
   <span>{{ formatCurrency(row.basePrice) }}</span>
+</ng-template>
+
+<ng-template #createdAtTemplate let-row>
+  <div class="flex flex-col">
+    <span class="text-sm">{{
+      $any(row).createdAt ? ($any(row).createdAt | date: 'dd MMM yyyy HH:mm:ss') : ''
+    }}</span>
+    @if ($any(row).updatedAt && $any(row).updatedAt !== $any(row).createdAt) {
+      <span class="text-xs text-muted-foreground">{{
+        $any(row).updatedAt ? ($any(row).updatedAt | date: 'dd MMM yyyy HH:mm:ss') : ''
+      }}</span>
+    }
+  </div>
 </ng-template>
 
 <app-confirm-dialog

--- a/frontend/src/app/shared/components/application-delete-dialog/application-delete-dialog-content.component.html
+++ b/frontend/src/app/shared/components/application-delete-dialog/application-delete-dialog-content.component.html
@@ -1,0 +1,29 @@
+<div class="space-y-4 text-sm">
+  <div class="space-y-1">
+    <p class="font-medium">
+      Delete application #{{ data.applicationId }}?
+    </p>
+    <p class="text-muted-foreground">
+      This application has a related invoice
+      @if (data.invoiceId) {
+        #{{ data.invoiceId }}
+      }.
+      Deleting the application will also delete the invoice and cannot be undone.
+    </p>
+  </div>
+
+  <label class="flex items-start gap-2 text-sm">
+    <input
+      type="checkbox"
+      class="mt-0.5"
+      (change)="confirmChecked.set(($event.target as HTMLInputElement).checked)"
+    />
+    <span>I understand this will delete the linked invoice too.</span>
+  </label>
+
+  @if (showValidation()) {
+    <div class="text-xs text-destructive">
+      Please confirm the invoice deletion before continuing.
+    </div>
+  }
+</div>

--- a/frontend/src/app/shared/components/application-delete-dialog/application-delete-dialog-content.component.ts
+++ b/frontend/src/app/shared/components/application-delete-dialog/application-delete-dialog-content.component.ts
@@ -1,0 +1,36 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+
+import { Z_MODAL_DATA } from '@/shared/components/dialog';
+
+export interface ApplicationDeleteDialogData {
+  applicationId: number;
+  invoiceId?: number | null;
+}
+
+export interface ApplicationDeleteDialogResult {
+  confirmed: boolean;
+}
+
+@Component({
+  selector: 'app-application-delete-dialog-content',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './application-delete-dialog-content.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ApplicationDeleteDialogContentComponent {
+  readonly data = inject<ApplicationDeleteDialogData>(Z_MODAL_DATA);
+  readonly confirmChecked = signal(false);
+  readonly showValidation = signal(false);
+
+  validate(): boolean {
+    const valid = this.confirmChecked();
+    this.showValidation.set(!valid);
+    return valid;
+  }
+
+  getResult(): ApplicationDeleteDialogResult {
+    return { confirmed: true };
+  }
+}

--- a/frontend/src/app/shared/components/application-delete-dialog/application-delete-dialog.component.ts
+++ b/frontend/src/app/shared/components/application-delete-dialog/application-delete-dialog.component.ts
@@ -1,0 +1,82 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+
+import { ZardDialogService } from '@/shared/components/dialog';
+import type { ZardDialogRef } from '@/shared/components/dialog/dialog-ref';
+
+import {
+  ApplicationDeleteDialogContentComponent,
+  type ApplicationDeleteDialogData,
+  type ApplicationDeleteDialogResult,
+} from './application-delete-dialog-content.component';
+
+export type { ApplicationDeleteDialogData, ApplicationDeleteDialogResult };
+
+@Component({
+  selector: 'app-application-delete-dialog',
+  standalone: true,
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ApplicationDeleteDialogComponent {
+  isOpen = input<boolean>(false);
+  data = input<ApplicationDeleteDialogData | null>(null);
+
+  confirmed = output<ApplicationDeleteDialogResult>();
+  cancelled = output<void>();
+
+  private dialogService = inject(ZardDialogService);
+  private destroyRef = inject(DestroyRef);
+  private dialogRef = signal<ZardDialogRef | null>(null);
+
+  constructor() {
+    effect(() => {
+      const open = this.isOpen();
+      const dialogData = this.data();
+      const current = this.dialogRef();
+
+      if (open && dialogData && !current) {
+        const ref = this.dialogService.create({
+          zTitle: 'Delete Application',
+          zContent: ApplicationDeleteDialogContentComponent,
+          zOkText: 'Delete Application',
+          zCancelText: 'Cancel',
+          zOkDestructive: true,
+          zData: dialogData,
+          zOnOk: (content) => {
+            if (!content.validate()) {
+              return false;
+            }
+            this.confirmed.emit(content.getResult());
+            return;
+          },
+          zOnCancel: () => {
+            this.cancelled.emit();
+          },
+        });
+
+        this.dialogRef.set(ref);
+      }
+
+      if ((!open || !dialogData) && current) {
+        current.close();
+        this.dialogRef.set(null);
+      }
+    });
+
+    this.destroyRef.onDestroy(() => {
+      const current = this.dialogRef();
+      if (current) {
+        current.close();
+      }
+    });
+  }
+}

--- a/frontend/src/app/shared/components/application-delete-dialog/index.ts
+++ b/frontend/src/app/shared/components/application-delete-dialog/index.ts
@@ -1,0 +1,1 @@
+export * from './application-delete-dialog.component';

--- a/frontend/src/app/shared/components/document-preview/document-preview.component.html
+++ b/frontend/src/app/shared/components/document-preview/document-preview.component.html
@@ -15,7 +15,7 @@
   </button>
 
   <ng-template #previewContent>
-    <z-popover class="p-2 w-72 sm:w-80">
+    <z-popover [class]="popoverClasses()">
       <div class="space-y-2">
         <div class="flex items-center justify-between">
           <span class="text-xs font-medium text-muted-foreground truncate">
@@ -33,19 +33,23 @@
                 <img
                   [src]="previewUrl()"
                   alt="PDF Preview"
-                  class="max-h-60 w-full object-contain"
+                  [class]="previewImageClasses()"
                 />
               } @else {
-                <div class="w-full h-60">
+                <div [class]="previewFrameClasses()">
                   <iframe [src]="sanitizedPreview()" class="w-full h-full border-0"></iframe>
                 </div>
               }
-            } @else {
+            } @else if (isImage()) {
               <img
                 [src]="previewUrl()"
                 alt="Document Preview"
-                class="max-h-60 w-full object-contain"
+                [class]="previewImageClasses()"
               />
+            } @else {
+              <div class="w-full flex items-center justify-center text-xs text-muted-foreground p-4">
+                Preview not available.
+              </div>
             }
           } @else {
             <div class="text-xs text-muted-foreground text-center p-4">Preview not available.</div>

--- a/frontend/src/app/shared/components/dropdown/dropdown.service.ts
+++ b/frontend/src/app/shared/components/dropdown/dropdown.service.ts
@@ -196,7 +196,21 @@ export class ZardDropdownService {
         case 'Escape':
           event.preventDefault();
           this.close();
-          this.triggerElement?.nativeElement.focus();
+          {
+            const trigger = this.triggerElement?.nativeElement as HTMLElement | undefined;
+            const row = trigger?.closest?.('tr[z-table-row], tr') as HTMLElement | null;
+            if (row) {
+              row.setAttribute('tabindex', '0');
+              try {
+                row.focus({ preventScroll: true });
+                row.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+              } catch (e) {
+                row.focus();
+              }
+            } else {
+              trigger?.focus();
+            }
+          }
           break;
         case 'Home':
           event.preventDefault();

--- a/frontend/src/app/shared/components/file-upload/file-upload.component.html
+++ b/frontend/src/app/shared/components/file-upload/file-upload.component.html
@@ -30,6 +30,23 @@
     </div>
   }
 
+  @if (showPreview()) {
+    <div class="rounded-md border bg-muted/10 p-3">
+      <div class="text-xs font-medium text-muted-foreground mb-2">Preview</div>
+      <div class="flex items-center justify-center overflow-hidden rounded-md bg-muted/20">
+        @if (previewType() === 'image') {
+          <img
+            [src]="previewUrl()"
+            alt="Selected file preview"
+            class="max-h-64 w-full object-contain"
+          />
+        } @else if (previewType() === 'pdf') {
+          <iframe [src]="sanitizedPreview()" class="h-64 w-full border-0"></iframe>
+        }
+      </div>
+    </div>
+  }
+
   @if (progress() !== null) {
     <div class="space-y-1">
       <div class="flex items-center justify-between text-xs text-muted-foreground">

--- a/frontend/src/app/shared/components/file-upload/file-upload.component.ts
+++ b/frontend/src/app/shared/components/file-upload/file-upload.component.ts
@@ -3,11 +3,15 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  computed,
+  inject,
   input,
   output,
   signal,
   viewChild,
 } from '@angular/core';
+
+import { DomSanitizer, type SafeResourceUrl } from '@angular/platform-browser';
 
 import { ZardButtonComponent } from '@/shared/components/button';
 import { mergeClasses } from '@/shared/utils/merge-classes';
@@ -27,12 +31,29 @@ export class FileUploadComponent {
   progress = input<number | null>(null);
   fileName = input<string | null>(null);
   helperText = input<string | null>(null);
+  previewUrl = input<string | null>(null);
+  previewType = input<'image' | 'pdf' | 'unknown'>('unknown');
 
   fileSelected = output<File>();
   cleared = output<void>();
 
   private readonly fileInput = viewChild.required<ElementRef<HTMLInputElement>>('fileInput');
   readonly isDragging = signal(false);
+  private sanitizer = inject(DomSanitizer);
+
+  readonly showPreview = computed(() => {
+    const url = this.previewUrl();
+    const type = this.previewType();
+    return Boolean(url) && (type === 'image' || type === 'pdf');
+  });
+
+  readonly sanitizedPreview = computed<SafeResourceUrl | null>(() => {
+    const url = this.previewUrl();
+    if (!url) {
+      return null;
+    }
+    return this.sanitizer.bypassSecurityTrustResourceUrl(url);
+  });
 
   onBrowseClick(): void {
     if (this.disabled()) {

--- a/frontend/src/app/shared/components/pagination-controls/pagination-controls.component.html
+++ b/frontend/src/app/shared/components/pagination-controls/pagination-controls.component.html
@@ -24,7 +24,12 @@
     Previous
   </button>
 
-  <div class="px-3 text-sm text-muted-foreground">Page {{ page() }} of {{ totalPages() }}</div>
+  <div class="px-3 text-sm text-muted-foreground">
+    Page {{ page() }} of {{ totalPages() }}
+    @if (totalItems() !== null) {
+      <span>({{ totalItems() }})</span>
+    }
+  </div>
 
   <button
     type="button"

--- a/frontend/src/app/shared/components/pagination-controls/pagination-controls.component.ts
+++ b/frontend/src/app/shared/components/pagination-controls/pagination-controls.component.ts
@@ -16,6 +16,7 @@ export class PaginationControlsComponent {
   page = input<number>(1);
   totalPages = input<number>(1);
   disabled = input<boolean>(false);
+  totalItems = input<number | null>(null);
 
   pageChange = output<number>();
 

--- a/frontend/src/app/shared/layouts/main-layout/main-layout.component.html
+++ b/frontend/src/app/shared/layouts/main-layout/main-layout.component.html
@@ -85,6 +85,7 @@
         <div class="pt-4 pb-1">
           <button
             #sidebarItem
+            #lettersToggle
             (click)="toggleLetters()"
             class="flex w-full items-center justify-between gap-3 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
           >


### PR DESCRIPTION
### Motivation
- Improve usability of list views by showing total record counts and an "Added/Updated" column so users can see page/record context at a glance.
- Fix keyboard/focus issues when opening/closing per-row dropdowns so Esc returns focus to the originating table row instead of leaving focus on the kebab button.
- Provide better document upload UX by adding inline previews inside the upload control and larger popover preview sizes, and support image previews (jpg/png) alongside PDFs.
- Make application deletion safer when a related invoice exists by adding a confirmation dialog requiring explicit user acknowledgement.

### Description
- Pagination and columns: added a `totalItems` input to `PaginationControlsComponent` and updated list pages (`customers`, `applications`, `products`, `invoices`) to pass the server `count` and render "Page X of Y (N)" and added a new "Added/Updated" column template for these lists.\
- Document preview and upload: extended `DocumentPreviewComponent` to accept `previewSize` and detect image/pdf mime types, generate medium/large previews and use `pdfjs` thumbnail fallback; enhanced `FileUploadComponent` to accept `previewUrl`/`previewType` and render an inline preview (image iframe for PDF).\
- Application document flow: `ApplicationDetailComponent` now sets inline upload preview URLs for selected files, shows inline previews in the upload modal, hides the "Optional Documents" card when empty, and updates application `status`/`isDocumentCollectionCompleted` when required documents become completed.\
- Keyboard/navigation and delete flow: changed dropdown service Escape handling to refocus the containing table row; preserved navigation state (`from`, `focusId`, `searchQuery`, `focusTable`) across navigation and wired it into `goBack()` handlers in list/detail/form components (customers, applications, products, invoices); added global Shift+(D,C,A,P,I,L) shortcuts in `MainLayoutComponent`; added an application-delete dialog that requires a checkbox confirmation when the application has a related invoice and wired it into the applications list actions.\
- New/modified files include the application-delete dialog components, preview sizing logic in `document-preview`, inline preview support in `file-upload`, pagination control and list templates/logic, dropdown keyboard-focus fix, and multiple router state updates across list/detail/form components.

### Testing
- No automated test suite was run as part of this change.\
- An attempt to capture a Playwright screenshot against `http://localhost:4200` failed with `ERR_EMPTY_RESPONSE` because the dev server was not running in this environment.\
- All changes were committed locally (27 files changed) and a PR draft was created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987deb401388329949d40d6e747f127)