### PR TITLE
chore(workflows): update triggers for E2E test workflows

### DIFF
--- a/.github/workflows/e2e-mock.yml
+++ b/.github/workflows/e2e-mock.yml
@@ -1,10 +1,7 @@
 name: E2E Tests (with mock)
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   e2e-mock:

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,10 +1,7 @@
 name: Playwright E2E (mock)
 
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+  workflow_dispatch:
 
 jobs:
   e2e:


### PR DESCRIPTION
This pull request updates the configuration of two GitHub Actions workflows by changing how they are triggered. Instead of running automatically on pushes or pull requests to main branches, these workflows will now only run when manually triggered.

Workflow trigger changes:

* [`.github/workflows/e2e-mock.yml`](diffhunk://#diff-d82add06a07eda9351e659a810391d4f2ad44357723e48023fc2e1182d3774a5L4-R4): Changed the trigger from automatic on `push` and `pull_request` to manual via `workflow_dispatch`.
* [`.github/workflows/playwright-e2e.yml`](diffhunk://#diff-11da17eb15fc2ccce3aeb0943bea8634e9112374b3f0ed1124eaec1548ba6961L4-R4): Changed the trigger from automatic on `push` and `pull_request` to manual via `workflow_dispatch`.* Change workflows to trigger only on manual dispatch.
* Remove push and pull request triggers for cleaner execution.