### PR TITLE
fix(reports): use type-only ChartData import to resolve Angular build errors

### DIFF
--- a/frontend/src/app/features/reports/reports.component.ts
+++ b/frontend/src/app/features/reports/reports.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { ChartData } from 'chart.js';
+import type { ChartData } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
 
 import { ReportsService } from '@/core/services/reports.service';


### PR DESCRIPTION
### Motivation
- Fix Angular build failures caused by importing runtime-only exports from `chart.js`/`ng2-charts` so the standalone `ReportsComponent` can be statically analyzed and compiled.

### Description
- Use a type-only import for `ChartData` (`import type { ChartData } from 'chart.js';`) and keep `BaseChartDirective` in the component `imports` so the directive remains available at runtime.

### Testing
- Ran dependency install and build in `frontend/` with `bun install` and `bun run build`, and the Angular build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b227bd84832eb1dcb4bebc260301)