### PR TITLE
feat(storage): ocr preview storage & migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,5 +135,27 @@ jobs:
               echo "ℹ️  INITIALIZE_DB != true — skipping one-off seeding tasks"
             fi
 
+            # Optionally run cloud-storage migration tasks if explicitly requested via .env (MIGRATE_STORAGE_ASSETS=true)
+            if [ "${MIGRATE_STORAGE_ASSETS:-false}" = "true" ]; then
+              echo "☁️  MIGRATE_STORAGE_ASSETS=true — running migrate_storage_assets inside bs-core container via exec with retries"
+
+              ATTEMPTS=0
+              MAX_ATTEMPTS=6
+              SLEEP_SECONDS=10
+              until docker compose exec -T bs-core /bin/bash -lc 'PYTHON_BIN="python"; if [ -x "/opt/venv/bin/python" ]; then PYTHON_BIN="/opt/venv/bin/python"; fi; $PYTHON_BIN manage.py migrate_storage_assets'; do
+                ATTEMPTS=$((ATTEMPTS + 1))
+                if [ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]; then
+                  echo "❌ Failed to run migrate_storage_assets after $ATTEMPTS attempts. Aborting."
+                  exit 1
+                fi
+                echo "⚠️ bs-core not ready for exec (attempt $ATTEMPTS/$MAX_ATTEMPTS), retrying in ${SLEEP_SECONDS}s..."
+                sleep "$SLEEP_SECONDS"
+              done
+
+              echo "✅ Storage migration command completed."
+            else
+              echo "ℹ️  MIGRATE_STORAGE_ASSETS != true — skipping storage migration tasks"
+            fi
+
             echo "🧹  Cleaning up unused data …"
             docker system prune -f

--- a/backend/api/serializers/__init__.py
+++ b/backend/api/serializers/__init__.py
@@ -3,6 +3,7 @@ from .country_code_serializer import CountryCodeSerializer
 from .customer_serializer import CustomerSerializer
 from .dashboard_serializer import DashboardStatsSerializer
 from .doc_application_serializer import (
+    CustomerApplicationHistorySerializer,
     CustomerUninvoicedApplicationSerializer,
     DocApplicationCreateUpdateSerializer,
     DocApplicationDetailSerializer,

--- a/backend/api/tests/test_ocr_status_preview_url.py
+++ b/backend/api/tests/test_ocr_status_preview_url.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from api.views import OCRViewSet
+from core.models import OCRJob
+
+
+class OCRStatusPreviewUrlTests(TestCase):
+    def test_completed_status_adds_preview_url_from_storage_path(self):
+        user = get_user_model().objects.create_user(username="ocr-user", password="pw")
+        job = OCRJob.objects.create(
+            status=OCRJob.STATUS_COMPLETED,
+            progress=100,
+            file_path="tmpfiles/in.png",
+            file_url="https://example.com/in.png",
+            result={
+                "mrz_data": {"number": "ABC123"},
+                "preview_storage_path": "ocr_previews/job-1.png",
+            },
+        )
+
+        factory = APIRequestFactory()
+        request = factory.get(f"/api/ocr/status/{job.id}/")
+        force_authenticate(request, user=user)
+        view = OCRViewSet.as_view({"get": "status"})
+
+        with patch("api.views.get_ocr_preview_url", return_value="https://signed.example.com/ocr_previews/job-1.png"):
+            response = view(request, job_id=str(job.id))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get("preview_url"), "https://signed.example.com/ocr_previews/job-1.png")
+        self.assertEqual(response.data.get("previewUrl"), "https://signed.example.com/ocr_previews/job-1.png")
+        self.assertEqual(response.data.get("mrz_data"), {"number": "ABC123"})

--- a/backend/business_suite/settings/base.py
+++ b/backend/business_suite/settings/base.py
@@ -694,6 +694,7 @@ def get_dropbox_token():
 
 # Storage configuration
 USE_CLOUD_STORAGE = _parse_bool(os.getenv("USE_CLOUD_STORAGE", "False"))
+OCR_PREVIEW_STORAGE_PREFIX = os.getenv("OCR_PREVIEW_STORAGE_PREFIX", "ocr_previews")
 _settings_module = os.getenv("DJANGO_SETTINGS_MODULE", "")
 _default_bucket_name = "crmrevisbali" if _settings_module.endswith(".prod") else "crmrevisbalidev"
 

--- a/backend/business_suite/static/js/document_update.js
+++ b/backend/business_suite/static/js/document_update.js
@@ -92,7 +92,11 @@
     setFormFieldValue("id_metadata_display", JSON.stringify(mrz));
     toggleSpinnerDisplay(false, "ocr_check_btn_id", "ocr_check_spinner");
 
-    if (data.b64_resized_image) {
+    var previewUrl = data.preview_url || data.previewUrl;
+    if (previewUrl && resizedImage) {
+      resizedImage.src = previewUrl;
+      resizedImage.style.display = "block";
+    } else if (data.b64_resized_image) {
       if (resizedImage) {
         resizedImage.src = "data:image/jpeg;base64," + data.b64_resized_image;
         resizedImage.style.display = "block";

--- a/backend/business_suite/static/js/passport_import.js
+++ b/backend/business_suite/static/js/passport_import.js
@@ -514,8 +514,12 @@
 
         handleResponse(config, data);
         // Check both camelCase and snake_case for image preview
+        var previewUrl = data.previewUrl || data.preview_url;
         var previewImage = data.b64ResizedImage || data.b64_resized_image;
-        if (previewImage && previewEl) {
+        if (previewEl && previewUrl) {
+          previewEl.src = previewUrl;
+          previewEl.classList.remove("d-none");
+        } else if (previewImage && previewEl) {
           previewEl.src = "data:image/jpeg;base64," + previewImage;
           previewEl.classList.remove("d-none");
         }

--- a/backend/core/management/commands/migrate_files_to_s3.py
+++ b/backend/core/management/commands/migrate_files_to_s3.py
@@ -1,6 +1,8 @@
 import shutil
+import tempfile
 from pathlib import Path
 
+from core.models import DocumentOCRJob, OCRJob
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import SuspiciousFileOperation
@@ -8,29 +10,42 @@ from django.core.files.storage import default_storage
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import FileField, ImageField
 from django.utils._os import safe_join
+from invoices.models.import_job import InvoiceImportItem
 
 
 class Command(BaseCommand):
     help = (
-        "Upload local media files referenced by FileField/ImageField values to the current default storage "
-        "(intended for S3/R2 migrations)."
+        "Migrate local media files to default storage (S3/R2), including FileField/ImageField references "
+        "and extra directories (default_documents/tmpfiles), then rewire DB path/url fields."
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--dry-run",
             action="store_true",
-            help="Show what would be uploaded without writing anything to S3.",
+            help="Show what would be migrated without writing to object storage or DB.",
         )
         parser.add_argument(
             "--source-root",
             default=str(settings.MEDIA_ROOT),
             help="Local media root to read source files from (defaults to settings.MEDIA_ROOT).",
         )
+        parser.add_argument(
+            "--extra-dir",
+            action="append",
+            dest="extra_dirs",
+            default=None,
+            help="Extra directory (relative to source root) to migrate recursively. Can be used multiple times.",
+        )
 
     def handle(self, *args, **options):
-        dry_run = options["dry_run"]
+        dry_run = bool(options["dry_run"])
         source_root = Path(options["source_root"]).expanduser().resolve()
+        extra_dirs = list(options.get("extra_dirs") or [])
+        default_extra_dirs = ["default_documents", getattr(settings, "TMPFILES_FOLDER", "tmpfiles")]
+        for extra_dir in default_extra_dirs:
+            if extra_dir and extra_dir not in extra_dirs:
+                extra_dirs.append(extra_dir)
 
         if not source_root.exists():
             raise CommandError(f"Source root does not exist: {source_root}")
@@ -47,29 +62,110 @@ class Command(BaseCommand):
             else:
                 raise CommandError(message)
 
+        error_log_handle = tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix="migrate-files-to-s3-",
+            suffix=".log",
+            delete=False,
+        )
+        error_log_path = error_log_handle.name
+
         counters = {
             "checked": 0,
             "uploaded": 0,
             "would_upload": 0,
             "already_present": 0,
             "missing_local": 0,
+            "extra_files_discovered": 0,
+            "db_rows_rewired": 0,
             "errors": 0,
         }
+        path_mappings: dict[str, str] = {}
 
         self.stdout.write(
-            f"Scanning FileField/ImageField values using source root: {source_root} "
+            f"Scanning files using source root: {source_root} "
             f"(dry_run={dry_run}, bucket={getattr(settings, 'AWS_STORAGE_BUCKET_NAME', 'N/A')})"
         )
+        self.stdout.write(f"Including extra directories: {', '.join(extra_dirs) if extra_dirs else '(none)'}")
+        self.stdout.write(f"Error log file: {error_log_path}")
 
+        def _record_error(message: str):
+            counters["errors"] += 1
+            self.stderr.write(message)
+            error_log_handle.write(message + "\n")
+            error_log_handle.flush()
+
+        def _normalize_storage_key(raw_path: str) -> str:
+            normalized = (raw_path or "").strip().replace("\\", "/")
+            if normalized.startswith("./"):
+                normalized = normalized[2:]
+            return normalized.lstrip("/")
+
+        def _to_storage_key(path_or_key: str) -> str:
+            normalized = (path_or_key or "").strip()
+            if not normalized:
+                return ""
+            candidate = Path(normalized)
+            if candidate.is_absolute():
+                try:
+                    return candidate.resolve().relative_to(source_root).as_posix()
+                except Exception:
+                    return _normalize_storage_key(normalized)
+            return _normalize_storage_key(normalized)
+
+        def _migrate_path(storage_key: str):
+            if not storage_key:
+                return
+            counters["checked"] += 1
+            if storage_key in path_mappings:
+                return
+
+            try:
+                local_path = safe_join(str(source_root), storage_key)
+            except SuspiciousFileOperation:
+                _record_error(f"[ERROR] Suspicious storage key: {storage_key}")
+                return
+
+            local_file = Path(local_path)
+            if not local_file.exists():
+                counters["missing_local"] += 1
+                return
+
+            try:
+                object_exists = default_storage.exists(storage_key)
+            except Exception as exc:
+                _record_error(f"[ERROR] Could not check destination object for {storage_key}: {exc}")
+                return
+
+            if object_exists:
+                counters["already_present"] += 1
+                path_mappings[storage_key] = storage_key
+                return
+
+            if dry_run:
+                counters["would_upload"] += 1
+                path_mappings[storage_key] = storage_key
+                self.stdout.write(f"[DRY RUN] Would upload: {storage_key}")
+                return
+
+            try:
+                with local_file.open("rb") as source_handle, default_storage.open(storage_key, "wb") as target_handle:
+                    shutil.copyfileobj(source_handle, target_handle, length=1024 * 1024)
+            except Exception as exc:
+                _record_error(f"[ERROR] Failed to upload {storage_key}: {exc}")
+                return
+
+            counters["uploaded"] += 1
+            path_mappings[storage_key] = storage_key
+            self.stdout.write(f"[UPLOADED] {storage_key}")
+
+        # Pass 1: FileField/ImageField references.
         for model in apps.get_models():
             if model._meta.proxy:
                 continue
 
-            file_fields = [
-                field
-                for field in model._meta.concrete_fields
-                if isinstance(field, (FileField, ImageField))
-            ]
+            file_fields = [field for field in model._meta.concrete_fields if isinstance(field, (FileField, ImageField))]
             if not file_fields:
                 continue
 
@@ -82,52 +178,99 @@ class Command(BaseCommand):
 
                 for obj in queryset.iterator(chunk_size=500):
                     file_attr = getattr(obj, field.name)
-                    file_name = getattr(file_attr, "name", None)
-                    if not file_name:
+                    raw_path = getattr(file_attr, "name", None) or ""
+                    storage_key = _to_storage_key(raw_path)
+                    if not storage_key:
                         continue
 
-                    counters["checked"] += 1
+                    _migrate_path(storage_key)
 
+                    if raw_path != storage_key:
+                        if dry_run:
+                            self.stdout.write(
+                                f"[DRY RUN] Would rewire {model._meta.label}#{obj.pk}.{field.name}: "
+                                f"{raw_path} -> {storage_key}"
+                            )
+                        else:
+                            setattr(obj, field.name, storage_key)
+                            try:
+                                obj.save(update_fields=[field.name])
+                                counters["db_rows_rewired"] += 1
+                            except Exception as exc:
+                                _record_error(
+                                    f"[ERROR] Failed rewiring {model._meta.label}#{obj.pk}.{field.name}: {exc}"
+                                )
+
+        # Pass 2: extra directories.
+        for extra_dir in extra_dirs:
+            extra_dir_norm = _normalize_storage_key(extra_dir)
+            if not extra_dir_norm:
+                continue
+            local_extra_dir = source_root / extra_dir_norm
+            if not local_extra_dir.exists() or not local_extra_dir.is_dir():
+                self.stdout.write(f"[WARN] Extra directory not found, skipping: {local_extra_dir}")
+                continue
+
+            for local_file in local_extra_dir.rglob("*"):
+                if not local_file.is_file():
+                    continue
+                try:
+                    storage_key = local_file.resolve().relative_to(source_root).as_posix()
+                except Exception:
+                    _record_error(f"[ERROR] Could not compute relative key for {local_file}")
+                    continue
+                counters["extra_files_discovered"] += 1
+                _migrate_path(storage_key)
+
+        # Pass 3: path/url rewiring for non-FileField path users.
+        migrated_keys = set(path_mappings.keys())
+
+        def _rewire_path_url_model(model, path_field: str, url_field: str | None):
+            queryset = model.objects.exclude(**{f"{path_field}": ""}).exclude(**{f"{path_field}__isnull": True})
+            for obj in queryset.iterator(chunk_size=500):
+                raw_path = getattr(obj, path_field, "") or ""
+                storage_key = _to_storage_key(raw_path)
+                if storage_key not in migrated_keys:
+                    continue
+
+                update_fields = []
+                if raw_path != storage_key:
+                    setattr(obj, path_field, storage_key)
+                    update_fields.append(path_field)
+
+                if url_field:
                     try:
-                        local_path = safe_join(str(source_root), file_name)
-                    except SuspiciousFileOperation:
-                        counters["errors"] += 1
-                        self.stderr.write(
-                            f"[ERROR] Suspicious file path for {model._meta.label}#{obj.pk}.{field.name}: {file_name}"
-                        )
-                        continue
-
-                    local_file = Path(local_path)
-                    if not local_file.exists():
-                        counters["missing_local"] += 1
-                        continue
-
-                    try:
-                        if default_storage.exists(file_name):
-                            counters["already_present"] += 1
-                            continue
+                        new_url = default_storage.url(storage_key)
                     except Exception as exc:
-                        counters["errors"] += 1
-                        self.stderr.write(
-                            f"[ERROR] Could not check destination object for {file_name}: {exc}"
-                        )
+                        _record_error(f"[ERROR] Failed generating URL for {model.__name__}#{obj.pk}: {exc}")
                         continue
+                    current_url = getattr(obj, url_field, "") or ""
+                    if current_url != new_url:
+                        setattr(obj, url_field, new_url)
+                        update_fields.append(url_field)
 
-                    if dry_run:
-                        counters["would_upload"] += 1
-                        self.stdout.write(f"[DRY RUN] Would upload: {file_name}")
-                        continue
+                if not update_fields:
+                    continue
 
-                    try:
-                        with local_file.open("rb") as source_handle, default_storage.open(file_name, "wb") as target_handle:
-                            shutil.copyfileobj(source_handle, target_handle, length=1024 * 1024)
-                    except Exception as exc:
-                        counters["errors"] += 1
-                        self.stderr.write(f"[ERROR] Failed to upload {file_name}: {exc}")
-                        continue
+                if dry_run:
+                    self.stdout.write(
+                        f"[DRY RUN] Would rewire {model.__name__}#{obj.pk}: {', '.join(update_fields)}"
+                    )
+                    continue
 
-                    counters["uploaded"] += 1
-                    self.stdout.write(f"[UPLOADED] {file_name}")
+                if hasattr(obj, "updated_at") and "updated_at" not in update_fields:
+                    update_fields.append("updated_at")
+                try:
+                    obj.save(update_fields=update_fields)
+                    counters["db_rows_rewired"] += 1
+                except Exception as exc:
+                    _record_error(f"[ERROR] Failed rewiring {model.__name__}#{obj.pk}: {exc}")
+
+        _rewire_path_url_model(OCRJob, "file_path", "file_url")
+        _rewire_path_url_model(DocumentOCRJob, "file_path", "file_url")
+        _rewire_path_url_model(InvoiceImportItem, "file_path", None)
+
+        error_log_handle.close()
 
         summary = (
             "Migration summary: "
@@ -135,7 +278,14 @@ class Command(BaseCommand):
             f"uploaded={counters['uploaded']}, "
             f"would_upload={counters['would_upload']}, "
             f"already_present={counters['already_present']}, "
+            f"extra_files_discovered={counters['extra_files_discovered']}, "
             f"missing_local={counters['missing_local']}, "
+            f"db_rows_rewired={counters['db_rows_rewired']}, "
             f"errors={counters['errors']}"
         )
-        self.stdout.write(self.style.SUCCESS(summary))
+        if counters["errors"] > 0:
+            self.stdout.write(self.style.WARNING(summary))
+            self.stdout.write(self.style.WARNING(f"Migration errors logged to: {error_log_path}"))
+        else:
+            self.stdout.write(self.style.SUCCESS(summary))
+            self.stdout.write(f"No migration errors logged. Error log file: {error_log_path}")

--- a/backend/core/management/commands/migrate_ocr_previews_to_storage.py
+++ b/backend/core/management/commands/migrate_ocr_previews_to_storage.py
@@ -1,0 +1,106 @@
+from django.core.management.base import BaseCommand
+
+from core.models import OCRJob
+from core.services.ocr_preview_storage import upload_ocr_preview_from_base64
+
+
+class Command(BaseCommand):
+    help = (
+        "Migrate OCRJob preview images stored as base64 in result JSON to object storage "
+        "and replace them with preview_storage_path."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be migrated without writing changes to DB/storage.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=200,
+            help="Queryset iterator batch size (default: 200).",
+        )
+        parser.add_argument(
+            "--keep-b64",
+            action="store_true",
+            help="Keep b64_resized_image in result after migration (default removes it).",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = bool(options["dry_run"])
+        batch_size = int(options["batch_size"] or 200)
+        keep_b64 = bool(options["keep_b64"])
+
+        counters = {
+            "checked": 0,
+            "migrated": 0,
+            "would_migrate": 0,
+            "skipped_no_b64": 0,
+            "skipped_has_storage_path": 0,
+            "errors": 0,
+        }
+
+        queryset = OCRJob.objects.exclude(result__isnull=True).only("id", "result", "updated_at").order_by("created_at")
+
+        for job in queryset.iterator(chunk_size=batch_size):
+            counters["checked"] += 1
+
+            result = job.result if isinstance(job.result, dict) else {}
+            b64_payload = result.get("b64_resized_image") or result.get("b64ResizedImage")
+            if not b64_payload:
+                counters["skipped_no_b64"] += 1
+                continue
+
+            if result.get("preview_storage_path"):
+                counters["skipped_has_storage_path"] += 1
+                continue
+
+            if dry_run:
+                counters["would_migrate"] += 1
+                self.stdout.write(f"[DRY RUN] Would migrate OCRJob {job.id}")
+                continue
+
+            try:
+                storage_path = upload_ocr_preview_from_base64(
+                    job_id=str(job.id),
+                    payload=b64_payload,
+                    extension="png",
+                    overwrite=True,
+                )
+            except Exception as exc:
+                counters["errors"] += 1
+                self.stderr.write(f"[ERROR] OCRJob {job.id}: {exc}")
+                continue
+
+            result["preview_storage_path"] = storage_path
+            result["preview_mime_type"] = "image/png"
+            if not keep_b64:
+                result.pop("b64_resized_image", None)
+                result.pop("b64ResizedImage", None)
+
+            try:
+                job.result = result
+                job.save(update_fields=["result", "updated_at"])
+            except Exception as exc:
+                counters["errors"] += 1
+                self.stderr.write(f"[ERROR] Failed to save OCRJob {job.id}: {exc}")
+                continue
+
+            counters["migrated"] += 1
+            self.stdout.write(self.style.SUCCESS(f"[MIGRATED] OCRJob {job.id} -> {storage_path}"))
+
+        summary = (
+            "OCR preview migration summary: "
+            f"checked={counters['checked']}, "
+            f"migrated={counters['migrated']}, "
+            f"would_migrate={counters['would_migrate']}, "
+            f"skipped_no_b64={counters['skipped_no_b64']}, "
+            f"skipped_has_storage_path={counters['skipped_has_storage_path']}, "
+            f"errors={counters['errors']}"
+        )
+        if counters["errors"]:
+            self.stdout.write(self.style.WARNING(summary))
+        else:
+            self.stdout.write(self.style.SUCCESS(summary))

--- a/backend/core/management/commands/migrate_storage_assets.py
+++ b/backend/core/management/commands/migrate_storage_assets.py
@@ -1,0 +1,83 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = (
+        "Run all cloud-storage migration steps: migrate local media files/directories to object storage "
+        "and migrate OCR preview payloads from DB base64 to object storage."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be migrated without writing to object storage or DB.",
+        )
+        parser.add_argument(
+            "--source-root",
+            help="Local media root for file migration (forwarded to migrate_files_to_s3).",
+        )
+        parser.add_argument(
+            "--extra-dir",
+            action="append",
+            dest="extra_dirs",
+            default=None,
+            help="Extra directory (relative to source root) for file migration. Can be used multiple times.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=200,
+            help="Batch size for OCR preview migration queryset iterator (default: 200).",
+        )
+        parser.add_argument(
+            "--keep-b64",
+            action="store_true",
+            help="Keep b64_resized_image in OCRJob.result after preview migration.",
+        )
+        parser.add_argument(
+            "--skip-files",
+            action="store_true",
+            help="Skip file/directory migration command.",
+        )
+        parser.add_argument(
+            "--skip-ocr-previews",
+            action="store_true",
+            help="Skip OCR preview migration command.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = bool(options.get("dry_run"))
+        source_root = options.get("source_root")
+        extra_dirs = list(options.get("extra_dirs") or [])
+        batch_size = int(options.get("batch_size") or 200)
+        keep_b64 = bool(options.get("keep_b64"))
+        skip_files = bool(options.get("skip_files"))
+        skip_ocr_previews = bool(options.get("skip_ocr_previews"))
+
+        if skip_files and skip_ocr_previews:
+            self.stdout.write("Nothing to do: both --skip-files and --skip-ocr-previews are set.")
+            return
+
+        if not skip_files:
+            self.stdout.write("Running migrate_files_to_s3...")
+            migrate_files_kwargs = {"dry_run": dry_run}
+            if source_root:
+                migrate_files_kwargs["source_root"] = source_root
+            if extra_dirs:
+                migrate_files_kwargs["extra_dirs"] = extra_dirs
+            call_command("migrate_files_to_s3", stdout=self.stdout, stderr=self.stderr, **migrate_files_kwargs)
+            self.stdout.write(self.style.SUCCESS("migrate_files_to_s3 completed."))
+
+        if not skip_ocr_previews:
+            self.stdout.write("Running migrate_ocr_previews_to_storage...")
+            migrate_previews_kwargs = {
+                "dry_run": dry_run,
+                "batch_size": batch_size,
+                "keep_b64": keep_b64,
+            }
+            call_command("migrate_ocr_previews_to_storage", stdout=self.stdout, stderr=self.stderr, **migrate_previews_kwargs)
+            self.stdout.write(self.style.SUCCESS("migrate_ocr_previews_to_storage completed."))
+
+        self.stdout.write(self.style.SUCCESS("migrate_storage_assets completed successfully."))

--- a/backend/core/services/ocr_preview_storage.py
+++ b/backend/core/services/ocr_preview_storage.py
@@ -1,0 +1,73 @@
+import base64
+import binascii
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
+
+def _normalize_base64_payload(payload: str) -> str:
+    value = payload.strip()
+    if value.startswith("data:") and "," in value:
+        value = value.split(",", 1)[1]
+
+    missing_padding = len(value) % 4
+    if missing_padding:
+        value += "=" * (4 - missing_padding)
+
+    return value
+
+
+def decode_base64_image(payload: str) -> bytes:
+    if not payload:
+        raise ValueError("Empty base64 payload")
+
+    normalized_payload = _normalize_base64_payload(payload)
+    try:
+        image_bytes = base64.b64decode(normalized_payload, validate=False)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("Invalid base64 image payload") from exc
+
+    if not image_bytes:
+        raise ValueError("Decoded base64 payload is empty")
+    return image_bytes
+
+
+def get_ocr_preview_storage_prefix() -> str:
+    prefix = str(getattr(settings, "OCR_PREVIEW_STORAGE_PREFIX", "ocr_previews") or "ocr_previews")
+    return prefix.strip("/ ")
+
+
+def build_ocr_preview_storage_path(job_id: str, extension: str = "png") -> str:
+    ext = extension.lower().lstrip(".") or "png"
+    return f"{get_ocr_preview_storage_prefix()}/{job_id}.{ext}"
+
+
+def upload_ocr_preview_bytes(job_id: str, image_bytes: bytes, extension: str = "png", overwrite: bool = True) -> str:
+    target_path = build_ocr_preview_storage_path(str(job_id), extension=extension)
+
+    if overwrite:
+        try:
+            if default_storage.exists(target_path):
+                default_storage.delete(target_path)
+        except Exception:
+            pass
+
+    return default_storage.save(target_path, ContentFile(image_bytes))
+
+
+def upload_ocr_preview_from_base64(
+    job_id: str, payload: str, extension: str = "png", overwrite: bool = True
+) -> str:
+    return upload_ocr_preview_bytes(
+        job_id=str(job_id),
+        image_bytes=decode_base64_image(payload),
+        extension=extension,
+        overwrite=overwrite,
+    )
+
+
+def get_ocr_preview_url(storage_path: str | None) -> str | None:
+    if not storage_path:
+        return None
+    return default_storage.url(storage_path)

--- a/backend/core/tasks/ocr.py
+++ b/backend/core/tasks/ocr.py
@@ -1,6 +1,7 @@
 import mimetypes
 import os
 import traceback
+from io import BytesIO
 
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -9,6 +10,7 @@ from huey.contrib.djhuey import db_task
 from core.models import OCRJob
 from core.services.ai_client import AIConnectionError
 from core.services.logger_service import Logger
+from core.services.ocr_preview_storage import upload_ocr_preview_bytes
 from core.utils.imgutils import convert_and_resize_image
 from core.utils.passport_ocr import extract_mrz_data, extract_passport_with_ai
 
@@ -66,21 +68,31 @@ def run_ocr_job(job_id: str, task=None) -> None:
         if width:
             width = int(width)
 
-        img_str = None
+        preview_storage_path = None
         if img_preview or resize:
             logger.info("Generating image preview/resized version")
             with default_storage.open(job.file_path, "rb") as handle:
-                _, img_bytes = convert_and_resize_image(
+                img, _ = convert_and_resize_image(
                     handle,
                     file_type,
-                    return_encoded=img_preview,
+                    return_encoded=False,
                     resize=resize,
                     base_width=width,
                 )
                 if img_preview:
-                    img_str = img_bytes.decode("utf-8") if isinstance(img_bytes, bytes) else img_bytes
+                    preview_buffer = BytesIO()
+                    img.save(preview_buffer, format="PNG", compress_level=1, optimize=False)
+                    preview_storage_path = upload_ocr_preview_bytes(
+                        job_id=str(job.id),
+                        image_bytes=preview_buffer.getvalue(),
+                        extension="png",
+                        overwrite=True,
+                    )
 
-        response_data = {"b64_resized_image": img_str, "mrz_data": mrz_data}
+        response_data = {"mrz_data": mrz_data}
+        if preview_storage_path:
+            response_data["preview_storage_path"] = preview_storage_path
+            response_data["preview_mime_type"] = "image/png"
         if isinstance(mrz_data, dict) and "ai_error" in mrz_data:
             response_data["ai_warning"] = mrz_data.pop("ai_error")
 

--- a/backend/core/tests/e2e/test_huey_redis_e2e.py
+++ b/backend/core/tests/e2e/test_huey_redis_e2e.py
@@ -6,9 +6,9 @@ import pytest
 from redis import Redis
 
 try:
-    from huey.contrib.redis_huey import RedisHuey
-except ModuleNotFoundError:  # pragma: no cover - compatibility with newer Huey import path.
     from huey import RedisHuey
+except ImportError:
+    from huey.contrib.redis_huey import RedisHuey  # type: ignore[import]
 
 
 def _running_inside_container() -> bool:
@@ -43,9 +43,7 @@ def test_huey_task_roundtrip_uses_redis_backend_e2e():
     try:
         redis_client.ping()
     except Exception as exc:
-        pytest.skip(
-            f"Redis is not reachable for Huey E2E on {redis_host}:{redis_port} (db {redis_db}): {exc}"
-        )
+        pytest.skip(f"Redis is not reachable for Huey E2E on {redis_host}:{redis_port} (db {redis_db}): {exc}")
 
     huey = RedisHuey(
         name=f"huey-e2e-{uuid.uuid4().hex}",

--- a/backend/core/tests/test_migrate_files_to_s3_command.py
+++ b/backend/core/tests/test_migrate_files_to_s3_command.py
@@ -1,0 +1,107 @@
+from io import BytesIO, StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from core.models import DocumentOCRJob, OCRJob
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+from invoices.models.import_job import InvoiceImportItem, InvoiceImportJob
+
+
+class MigrateFilesToS3CommandTests(TestCase):
+    def _fake_storage_open(self, name, mode="rb"):
+        if "w" not in mode:
+            raise ValueError("Test stub only supports write mode")
+        return BytesIO()
+
+    @override_settings(USE_CLOUD_STORAGE=True)
+    def test_migrates_extra_dirs_and_rewires_path_fields(self):
+        with TemporaryDirectory() as tmpdir:
+            source_root = Path(tmpdir)
+            tmp_file = source_root / "tmpfiles" / "sample.txt"
+            default_doc = source_root / "default_documents" / "default_sponsor_document.pdf"
+            tmp_file.parent.mkdir(parents=True, exist_ok=True)
+            default_doc.parent.mkdir(parents=True, exist_ok=True)
+            tmp_file.write_bytes(b"tmp")
+            default_doc.write_bytes(b"default")
+
+            job = OCRJob.objects.create(
+                status=OCRJob.STATUS_COMPLETED,
+                progress=100,
+                file_path=str(tmp_file.resolve()),
+                file_url="http://old.local/tmpfiles/sample.txt",
+                result={},
+            )
+            doc_job = DocumentOCRJob.objects.create(
+                status=DocumentOCRJob.STATUS_COMPLETED,
+                progress=100,
+                file_path=str(tmp_file.resolve()),
+                file_url="http://old.local/tmpfiles/sample.txt",
+            )
+            import_job = InvoiceImportJob.objects.create()
+            import_item = InvoiceImportItem.objects.create(
+                job=import_job,
+                filename="sample.txt",
+                file_path=str(tmp_file.resolve()),
+            )
+
+            with patch(
+                "core.management.commands.migrate_files_to_s3.default_storage.exists",
+                side_effect=lambda key: False,
+            ) as mock_exists, patch(
+                "core.management.commands.migrate_files_to_s3.default_storage.open",
+                side_effect=self._fake_storage_open,
+            ), patch(
+                "core.management.commands.migrate_files_to_s3.default_storage.url",
+                side_effect=lambda key: f"https://s3.example/{key}",
+            ):
+                out = StringIO()
+                call_command("migrate_files_to_s3", "--source-root", str(source_root), stdout=out)
+
+            job.refresh_from_db()
+            doc_job.refresh_from_db()
+            import_item.refresh_from_db()
+
+            self.assertEqual(job.file_path, "tmpfiles/sample.txt")
+            self.assertEqual(job.file_url, "https://s3.example/tmpfiles/sample.txt")
+            self.assertEqual(doc_job.file_path, "tmpfiles/sample.txt")
+            self.assertEqual(doc_job.file_url, "https://s3.example/tmpfiles/sample.txt")
+            self.assertEqual(import_item.file_path, "tmpfiles/sample.txt")
+
+            checked_keys = [call.args[0] for call in mock_exists.call_args_list]
+            self.assertIn("tmpfiles/sample.txt", checked_keys)
+            self.assertIn("default_documents/default_sponsor_document.pdf", checked_keys)
+
+    @override_settings(USE_CLOUD_STORAGE=True)
+    def test_dry_run_keeps_db_unchanged(self):
+        with TemporaryDirectory() as tmpdir:
+            source_root = Path(tmpdir)
+            tmp_file = source_root / "tmpfiles" / "sample.txt"
+            tmp_file.parent.mkdir(parents=True, exist_ok=True)
+            tmp_file.write_bytes(b"tmp")
+
+            job = OCRJob.objects.create(
+                status=OCRJob.STATUS_COMPLETED,
+                progress=100,
+                file_path=str(tmp_file.resolve()),
+                file_url="http://old.local/tmpfiles/sample.txt",
+                result={},
+            )
+
+            with patch(
+                "core.management.commands.migrate_files_to_s3.default_storage.exists",
+                side_effect=lambda key: False,
+            ), patch(
+                "core.management.commands.migrate_files_to_s3.default_storage.open",
+                side_effect=self._fake_storage_open,
+            ), patch(
+                "core.management.commands.migrate_files_to_s3.default_storage.url",
+                side_effect=lambda key: f"https://s3.example/{key}",
+            ):
+                out = StringIO()
+                call_command("migrate_files_to_s3", "--dry-run", "--source-root", str(source_root), stdout=out)
+
+            job.refresh_from_db()
+            self.assertEqual(job.file_path, str(tmp_file.resolve()))
+            self.assertEqual(job.file_url, "http://old.local/tmpfiles/sample.txt")

--- a/backend/core/tests/test_migrate_ocr_previews_command.py
+++ b/backend/core/tests/test_migrate_ocr_previews_command.py
@@ -1,0 +1,50 @@
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from core.models import OCRJob
+
+
+class MigrateOcrPreviewsCommandTests(TestCase):
+    def test_migrates_b64_preview_to_storage_path(self):
+        job = OCRJob.objects.create(
+            status=OCRJob.STATUS_COMPLETED,
+            progress=100,
+            file_path="tmpfiles/in.png",
+            file_url="https://example.com/in.png",
+            result={"b64_resized_image": "aGVsbG8=", "mrz_data": {"number": "ABC123"}},
+        )
+
+        with patch(
+            "core.management.commands.migrate_ocr_previews_to_storage.upload_ocr_preview_from_base64",
+            return_value=f"ocr_previews/{job.id}.png",
+        ) as mock_upload:
+            stdout = StringIO()
+            call_command("migrate_ocr_previews_to_storage", stdout=stdout)
+
+        job.refresh_from_db()
+        self.assertEqual(job.result.get("preview_storage_path"), f"ocr_previews/{job.id}.png")
+        self.assertEqual(job.result.get("preview_mime_type"), "image/png")
+        self.assertNotIn("b64_resized_image", job.result)
+        self.assertEqual(job.result.get("mrz_data"), {"number": "ABC123"})
+        mock_upload.assert_called_once()
+
+    def test_dry_run_does_not_modify_rows(self):
+        job = OCRJob.objects.create(
+            status=OCRJob.STATUS_COMPLETED,
+            progress=100,
+            file_path="tmpfiles/in.png",
+            file_url="https://example.com/in.png",
+            result={"b64_resized_image": "aGVsbG8=", "mrz_data": {"number": "ABC123"}},
+        )
+
+        with patch("core.management.commands.migrate_ocr_previews_to_storage.upload_ocr_preview_from_base64") as mock_upload:
+            stdout = StringIO()
+            call_command("migrate_ocr_previews_to_storage", "--dry-run", stdout=stdout)
+
+        job.refresh_from_db()
+        self.assertIn("b64_resized_image", job.result)
+        self.assertNotIn("preview_storage_path", job.result)
+        mock_upload.assert_not_called()

--- a/backend/core/tests/test_migrate_storage_assets_command.py
+++ b/backend/core/tests/test_migrate_storage_assets_command.py
@@ -1,0 +1,49 @@
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import SimpleTestCase
+
+
+class MigrateStorageAssetsCommandTests(SimpleTestCase):
+    @patch("core.management.commands.migrate_storage_assets.call_command")
+    def test_runs_both_commands_with_forwarded_options(self, mock_call_command):
+        stdout = StringIO()
+        call_command(
+            "migrate_storage_assets",
+            "--dry-run",
+            "--source-root",
+            "/tmp/media",
+            "--extra-dir",
+            "tmpfiles",
+            "--batch-size",
+            "123",
+            "--keep-b64",
+            stdout=stdout,
+        )
+
+        self.assertEqual(mock_call_command.call_count, 2)
+
+        first_call = mock_call_command.call_args_list[0]
+        self.assertEqual(first_call.args[0], "migrate_files_to_s3")
+        self.assertTrue(first_call.kwargs.get("dry_run"))
+        self.assertEqual(first_call.kwargs.get("source_root"), "/tmp/media")
+        self.assertEqual(first_call.kwargs.get("extra_dirs"), ["tmpfiles"])
+
+        second_call = mock_call_command.call_args_list[1]
+        self.assertEqual(second_call.args[0], "migrate_ocr_previews_to_storage")
+        self.assertTrue(second_call.kwargs.get("dry_run"))
+        self.assertEqual(second_call.kwargs.get("batch_size"), 123)
+        self.assertTrue(second_call.kwargs.get("keep_b64"))
+
+    @patch("core.management.commands.migrate_storage_assets.call_command")
+    def test_skip_flags(self, mock_call_command):
+        stdout = StringIO()
+        call_command("migrate_storage_assets", "--skip-files", stdout=stdout)
+        self.assertEqual(mock_call_command.call_count, 1)
+        self.assertEqual(mock_call_command.call_args_list[0].args[0], "migrate_ocr_previews_to_storage")
+
+        mock_call_command.reset_mock()
+        call_command("migrate_storage_assets", "--skip-ocr-previews", stdout=stdout)
+        self.assertEqual(mock_call_command.call_count, 1)
+        self.assertEqual(mock_call_command.call_args_list[0].args[0], "migrate_files_to_s3")

--- a/backend/core/tests/test_ocr_preview_storage.py
+++ b/backend/core/tests/test_ocr_preview_storage.py
@@ -1,0 +1,16 @@
+from django.test import SimpleTestCase, override_settings
+
+from core.services.ocr_preview_storage import build_ocr_preview_storage_path, decode_base64_image
+
+
+class OcrPreviewStorageHelpersTests(SimpleTestCase):
+    def test_decode_base64_image_supports_data_uri(self):
+        payload = "data:image/png;base64,aGVsbG8="
+        self.assertEqual(decode_base64_image(payload), b"hello")
+
+    @override_settings(OCR_PREVIEW_STORAGE_PREFIX="ocr/previews")
+    def test_build_storage_path_uses_configured_prefix(self):
+        self.assertEqual(
+            build_ocr_preview_storage_path("job-123", extension="png"),
+            "ocr/previews/job-123.png",
+        )

--- a/frontend/src/app/core/services/applications.service.ts
+++ b/frontend/src/app/core/services/applications.service.ts
@@ -133,6 +133,7 @@ export interface OcrStatusResponse {
   };
   aiWarning?: string;
   b64ResizedImage?: string;
+  previewUrl?: string;
 }
 
 export type UploadState =

--- a/frontend/src/app/core/services/ocr.service.ts
+++ b/frontend/src/app/core/services/ocr.service.ts
@@ -36,6 +36,7 @@ export interface OcrStatusResponse {
   };
   aiWarning?: string;
   b64ResizedImage?: string;
+  previewUrl?: string;
 }
 
 export interface PassportOcrOptions {

--- a/frontend/src/app/features/applications/application-detail/application-detail.component.ts
+++ b/frontend/src/app/features/applications/application-detail/application-detail.component.ts
@@ -940,6 +940,16 @@ export class ApplicationDetailComponent implements OnInit {
       this.router.navigate(['/applications'], { state: focusState });
       return;
     }
+    if (typeof st.returnUrl === 'string' && st.returnUrl.startsWith('/')) {
+      this.router.navigateByUrl(st.returnUrl, { state: { searchQuery: st.searchQuery ?? null } });
+      return;
+    }
+    if (st.from === 'customer-detail' && st.customerId) {
+      this.router.navigate(['/customers', st.customerId], {
+        state: { searchQuery: st.searchQuery ?? null },
+      });
+      return;
+    }
     if (st.from === 'customers') {
       this.router.navigate(['/customers'], { state: focusState });
       return;
@@ -1241,7 +1251,10 @@ export class ApplicationDetailComponent implements OnInit {
     this.ocrPolling.set(false);
     this.ocrStatus.set('Completed');
     this.ocrReviewData.set(status);
-    if (status.b64ResizedImage) {
+    const previewUrl = status.previewUrl ?? (status as { preview_url?: string }).preview_url;
+    if (previewUrl) {
+      this.ocrPreviewImage.set(previewUrl);
+    } else if (status.b64ResizedImage) {
       this.ocrPreviewImage.set(`data:image/jpeg;base64,${status.b64ResizedImage}`);
     }
     this.ocrReviewOpen.set(true);

--- a/frontend/src/app/features/customers/customer-detail/customer-detail.component.html
+++ b/frontend/src/app/features/customers/customer-detail/customer-detail.component.html
@@ -263,16 +263,30 @@
       </div>
     </z-card>
 
-    <!-- Uninvoiced Applications Section -->
+    <!-- Applications Section -->
     <z-card class="p-6">
-      <div class="flex items-center justify-between mb-4">
-        <h3 class="text-lg font-semibold border-b pb-2">Uninvoiced Applications</h3>
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h3 class="text-lg font-semibold border-b pb-2">Applications</h3>
         <button type="button" z-button zType="outline" zSize="sm" (click)="onCreateApplication()">
           New application
         </button>
       </div>
 
-      @if (uninvoicedApplications().length > 0) {
+      <div class="flex flex-wrap gap-2 mb-4">
+        @for (option of applicationFilterOptions; track option.value) {
+          <button
+            type="button"
+            z-button
+            zSize="sm"
+            [zType]="applicationsFilter() === option.value ? 'default' : 'outline'"
+            (click)="onApplicationsFilterChange(option.value)"
+          >
+            {{ option.label }}
+          </button>
+        }
+      </div>
+
+      @if (pagedApplications().length > 0) {
         <div class="overflow-x-auto">
           <table class="w-full border-collapse">
             <thead>
@@ -289,13 +303,24 @@
                   Status
                 </th>
                 <th class="text-left py-3 px-4 text-sm font-medium text-muted-foreground">
-                  Invoice Actions
+                  Invoice Status
+                </th>
+                <th class="text-left py-3 px-4 text-sm font-medium text-muted-foreground">Payment</th>
+                <th class="text-left py-3 px-4 text-sm font-medium text-muted-foreground">
+                  Actions
                 </th>
               </tr>
             </thead>
             <tbody>
-              @for (app of uninvoicedApplications(); track app.id) {
-                <tr class="border-b hover:bg-muted/50">
+              @for (app of pagedApplications(); track app.id) {
+                <tr
+                  class="border-b hover:bg-muted/50 cursor-pointer"
+                  role="button"
+                  tabindex="0"
+                  (click)="openApplicationDetails(app.id)"
+                  (keydown.enter)="openApplicationDetails(app.id)"
+                  (keydown.space)="$event.preventDefault(); openApplicationDetails(app.id)"
+                >
                   <td class="py-3 px-4 text-sm">
                     <span class="text-primary font-medium">{{ app.id }}</span>
                   </td>
@@ -312,12 +337,42 @@
                     }}</z-badge>
                   </td>
                   <td class="py-3 px-4 text-sm">
+                    @if (app.hasInvoice && app.invoiceId) {
+                      <div class="flex items-center gap-2">
+                        <z-badge zType="secondary">
+                          {{ app.invoiceStatusDisplay || (app.invoiceStatus | titlecase) }}
+                        </z-badge>
+                        <span class="text-xs text-muted-foreground">#{{ app.invoiceId }}</span>
+                      </div>
+                    } @else {
+                      <span class="text-muted-foreground">Uninvoiced</span>
+                    }
+                  </td>
+                  <td class="py-3 px-4 text-sm">
+                    <z-badge [zType]="getPaymentStatusBadgeType(app.paymentStatus)">
+                      {{ app.paymentStatusDisplay }}
+                    </z-badge>
+                  </td>
+                  <td class="py-3 px-4 text-sm">
                     <div class="flex flex-wrap items-center gap-2">
-                      <a z-button zType="outline" zSize="sm" [routerLink]="['/applications', app.id]">
+                      <button
+                        type="button"
+                        z-button
+                        zType="outline"
+                        zSize="sm"
+                        (click)="$event.stopPropagation(); openApplicationDetails(app.id)"
+                      >
                         View App
-                      </a>
+                      </button>
                       @if (app.hasInvoice && app.invoiceId) {
-                        <a z-button zType="outline" zSize="sm" [routerLink]="['/invoices', app.invoiceId]">
+                        <a
+                          z-button
+                          zType="outline"
+                          zSize="sm"
+                          [routerLink]="['/invoices', app.invoiceId]"
+                          [state]="invoiceNavigationState()"
+                          (click)="$event.stopPropagation()"
+                        >
                           View Invoice
                         </a>
                       } @else if (canCreateInvoice(app)) {
@@ -326,7 +381,7 @@
                           z-button
                           zType="success"
                           zSize="sm"
-                          (click)="onCreateInvoice(app.id)"
+                          (click)="$event.stopPropagation(); onCreateInvoice(app.id)"
                         >
                           Create Invoice
                         </button>
@@ -340,8 +395,40 @@
             </tbody>
           </table>
         </div>
+
+        <div class="flex flex-wrap items-center justify-between gap-3 mt-4">
+          <div class="text-sm text-muted-foreground">
+            Showing {{ applicationsStartIndex() }}-{{ applicationsEndIndex() }} of
+            {{ totalApplications() }}
+          </div>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              z-button
+              zType="outline"
+              zSize="sm"
+              [disabled]="!hasPreviousApplicationsPage()"
+              (click)="goToPreviousApplicationsPage()"
+            >
+              Previous
+            </button>
+            <span class="text-sm text-muted-foreground">
+              Page {{ applicationsPage() }} / {{ totalApplicationsPages() }}
+            </span>
+            <button
+              type="button"
+              z-button
+              zType="outline"
+              zSize="sm"
+              [disabled]="!hasNextApplicationsPage()"
+              (click)="goToNextApplicationsPage()"
+            >
+              Next
+            </button>
+          </div>
+        </div>
       } @else {
-        <div class="text-muted-foreground text-sm">No uninvoiced applications found.</div>
+        <div class="text-muted-foreground text-sm">No applications found for this filter.</div>
       }
     </z-card>
   </div>

--- a/frontend/src/app/features/customers/customer-form/customer-form.component.ts
+++ b/frontend/src/app/features/customers/customer-form/customer-form.component.ts
@@ -503,7 +503,10 @@ export class CustomerFormComponent implements OnInit {
 
     const previewImage =
       status.b64ResizedImage ?? (status as { b64_resized_image?: string }).b64_resized_image;
-    if (previewImage) {
+    const previewUrl = status.previewUrl ?? (status as { preview_url?: string }).preview_url;
+    if (previewUrl) {
+      this.passportPreviewUrl.set(previewUrl);
+    } else if (previewImage) {
       this.passportPreviewUrl.set(`data:image/jpeg;base64,${previewImage}`);
     }
 

--- a/frontend/src/app/features/invoices/invoice-detail/invoice-detail.component.ts
+++ b/frontend/src/app/features/invoices/invoice-detail/invoice-detail.component.ts
@@ -105,6 +105,24 @@ export class InvoiceDetailComponent implements OnInit {
       return;
     }
 
+    if (typeof st?.returnUrl === 'string' && st.returnUrl.startsWith('/')) {
+      this.router.navigateByUrl(st.returnUrl, {
+        state: {
+          searchQuery: st.searchQuery ?? this.originSearchQuery(),
+        },
+      });
+      return;
+    }
+
+    if (st?.from === 'customer-detail' && st?.customerId) {
+      this.router.navigate(['/customers', st.customerId], {
+        state: {
+          searchQuery: st.searchQuery ?? this.originSearchQuery(),
+        },
+      });
+      return;
+    }
+
     this.router.navigate(['/invoices'], { state: focusState });
   }
 
@@ -127,6 +145,8 @@ export class InvoiceDetailComponent implements OnInit {
       this.router.navigate(['/invoices', invoice.id, 'edit'], {
         state: {
           from: history.state?.from,
+          customerId: history.state?.customerId,
+          returnUrl: history.state?.returnUrl,
           focusId: invoice.id,
           searchQuery: this.originSearchQuery(),
         },

--- a/frontend/src/app/features/invoices/invoice-form/invoice-form.component.ts
+++ b/frontend/src/app/features/invoices/invoice-form/invoice-form.component.ts
@@ -158,6 +158,24 @@ export class InvoiceFormComponent implements OnInit {
       return;
     }
 
+    if (typeof st?.returnUrl === 'string' && st.returnUrl.startsWith('/')) {
+      this.router.navigateByUrl(st.returnUrl, {
+        state: {
+          searchQuery: st.searchQuery ?? null,
+        },
+      });
+      return;
+    }
+
+    if (st?.from === 'customer-detail' && st?.customerId) {
+      this.router.navigate(['/customers', st.customerId], {
+        state: {
+          searchQuery: st.searchQuery ?? null,
+        },
+      });
+      return;
+    }
+
     this.router.navigate(['/invoices'], { state: focusState });
   }
 
@@ -317,12 +335,21 @@ export class InvoiceFormComponent implements OnInit {
     } as InvoiceCreateUpdate;
 
     const fromState = history.state?.from;
+    const returnUrl = history.state?.returnUrl;
+    const customerId = history.state?.customerId;
+    const searchQuery = history.state?.searchQuery;
+    const detailState: Record<string, unknown> = {
+      from: fromState,
+      returnUrl,
+      customerId,
+      searchQuery,
+    };
 
     if (this.isEditMode() && this.invoice()) {
       this.invoicesApi.invoicesUpdate(this.invoice()!.id, payload).subscribe({
         next: (invoice: InvoiceCreateUpdate) => {
           this.toast.success('Invoice updated');
-          this.router.navigate(['/invoices', invoice.id], { state: { from: fromState } });
+          this.router.navigate(['/invoices', invoice.id], { state: detailState });
         },
         error: (error) => {
           applyServerErrorsToForm(this.form, error);
@@ -340,7 +367,7 @@ export class InvoiceFormComponent implements OnInit {
     this.invoicesApi.invoicesCreate(payload).subscribe({
       next: (invoice: InvoiceCreateUpdate) => {
         this.toast.success('Invoice created');
-        this.router.navigate(['/invoices', invoice.id], { state: { from: fromState } });
+        this.router.navigate(['/invoices', invoice.id], { state: detailState });
       },
       error: (error) => {
         applyServerErrorsToForm(this.form, error);


### PR DESCRIPTION
feat(storage): ocr preview storage & migration

* [CRITICAL] Add CLI commands to migrate local media and OCR previews
* Provide composite command to run file + OCR-preview migration steps
* Harden file migration: extra dirs, dry-run, error logging, DB rewiring
* Migrate OCR previews from base64 into object storage and update rows
* Persist OCR preview images during OCR processing and expose preview_url
* Surface signed preview URL in API and render previews in frontend UIs
* Add customer application history endpoint with filtering and paging UI
* Improve backup reporting with dump/archive sizes and top PG table sizes
* Make deploy pipeline optionally run storage migrations via env flag
* Add unit and integration tests for migration, preview, and API flows