### PR TITLE
feat(desktop): implement automated desktop update feed publishing

### DIFF
--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -5,9 +5,10 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'desktop/**'
-      - '.github/workflows/desktop-installers.yml'
+
+concurrency:
+  group: desktop-installers-main
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -25,6 +26,7 @@ jobs:
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DESKTOP_APP_VERSION: 0.1.${{ github.run_number }}
 
     steps:
       - name: Checkout
@@ -39,13 +41,134 @@ jobs:
         working-directory: desktop
         run: bun install
 
+      - name: Stamp Desktop Version
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const packageJsonPath = path.join(process.cwd(), 'desktop', 'package.json');
+          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+          const releaseVersion = String(process.env.DESKTOP_APP_VERSION || '').trim();
+          if (!releaseVersion) {
+            throw new Error('DESKTOP_APP_VERSION is required');
+          }
+          packageJson.version = releaseVersion;
+          fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf8');
+          console.log(`Desktop release version: ${releaseVersion}`);
+          NODE
+
       - name: Build Installer
         working-directory: desktop
         run: bun run dist:${{ matrix.target }}
+
+      - name: Collect Release Payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p desktop/update-payload
+          cp -f desktop/dist/latest*.yml desktop/update-payload/ 2>/dev/null || true
+          cp -f desktop/dist/*.exe desktop/update-payload/ 2>/dev/null || true
+          cp -f desktop/dist/*.dmg desktop/update-payload/ 2>/dev/null || true
+          cp -f desktop/dist/*.zip desktop/update-payload/ 2>/dev/null || true
+          cp -f desktop/dist/*.blockmap desktop/update-payload/ 2>/dev/null || true
+          ls -lah desktop/update-payload
 
       - name: Upload Desktop Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: revisbali-desktop-${{ matrix.target }}
-          path: desktop/dist/**
+          path: desktop/update-payload/**
           if-no-files-found: error
+
+  publish:
+    name: publish-update-feed
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    env:
+      VPS_HOST: ${{ secrets.VPS_HOST }}
+      VPS_USERNAME: ${{ secrets.VPS_USERNAME }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      REPO_DIR: ${{ secrets.REPO_DIR }}
+    steps:
+      - name: Download macOS payload
+        uses: actions/download-artifact@v4
+        with:
+          name: revisbali-desktop-mac
+          path: desktop-update-feed/mac
+
+      - name: Download Windows payload
+        uses: actions/download-artifact@v4
+        with:
+          name: revisbali-desktop-win
+          path: desktop-update-feed/win
+
+      - name: Merge payload files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p desktop-update-feed/all
+          cp -f desktop-update-feed/mac/* desktop-update-feed/all/ 2>/dev/null || true
+          cp -f desktop-update-feed/win/* desktop-update-feed/all/ 2>/dev/null || true
+          ls -lah desktop-update-feed/all
+          test -f desktop-update-feed/all/latest-mac.yml
+          test -f desktop-update-feed/all/latest.yml
+
+      - name: Publish update feed to VPS
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USERNAME}" ] || [ -z "${SSH_PRIVATE_KEY}" ]; then
+            echo "Missing required VPS SSH secrets (VPS_HOST, VPS_USERNAME, SSH_PRIVATE_KEY)"
+            exit 1
+          fi
+          if [ -z "${REPO_DIR}" ]; then
+            echo "Missing required secret: REPO_DIR"
+            exit 1
+          fi
+
+          mkdir -p "${HOME}/.ssh"
+          chmod 700 "${HOME}/.ssh"
+          printf '%s\n' "${SSH_PRIVATE_KEY}" > "${HOME}/.ssh/id_rsa"
+          chmod 600 "${HOME}/.ssh/id_rsa"
+          ssh-keyscan -H "${VPS_HOST}" >> "${HOME}/.ssh/known_hosts"
+          chmod 644 "${HOME}/.ssh/known_hosts"
+
+          ssh -i "${HOME}/.ssh/id_rsa" "${VPS_USERNAME}@${VPS_HOST}" \
+            "mkdir -p '\$HOME/desktop-updates-upload' && rm -f '\$HOME/desktop-updates-upload'/*"
+
+          scp -i "${HOME}/.ssh/id_rsa" desktop-update-feed/all/* \
+            "${VPS_USERNAME}@${VPS_HOST}:~/desktop-updates-upload/"
+
+          ssh -i "${HOME}/.ssh/id_rsa" "${VPS_USERNAME}@${VPS_HOST}" "REPO_DIR='${REPO_DIR}' bash -s" <<'EOF'
+          set -euo pipefail
+
+          if [ -z "${REPO_DIR:-}" ]; then
+            echo "REPO_DIR is empty"
+            exit 1
+          fi
+          if [ ! -f "${REPO_DIR}/.env" ]; then
+            echo "Missing ${REPO_DIR}/.env on VPS"
+            exit 1
+          fi
+
+          set -a
+          source "${REPO_DIR}/.env"
+          set +a
+
+          if [ -z "${DATA_PATH:-}" ]; then
+            echo "DATA_PATH is not defined in ${REPO_DIR}/.env"
+            exit 1
+          fi
+
+          UPDATE_DIR="${DATA_PATH}/desktop-updates"
+          mkdir -p "${UPDATE_DIR}"
+          rm -f "${UPDATE_DIR}"/*
+          cp -f "${HOME}/desktop-updates-upload/"* "${UPDATE_DIR}/"
+          rm -f "${HOME}/desktop-updates-upload/"*
+
+          echo "Desktop update feed published to ${UPDATE_DIR}"
+          ls -lah "${UPDATE_DIR}"
+          EOF

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,6 +2,7 @@
   "name": "revisbali-crm-desktop",
   "version": "0.1.0",
   "description": "Electron desktop wrapper for RevisBaliCRM",
+  "author": "Revis Bali CRM Team",
   "main": "main.js",
   "private": true,
   "packageManager": "bun@1.3.6",

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -173,6 +173,9 @@ services:
       - type: bind
         source: ${DATA_PATH}/logs
         target: /logs
+      - type: bind
+        source: ${DATA_PATH}/desktop-updates
+        target: /desktop-updates
     networks:
       - dockernet
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,6 +221,9 @@ services:
       - type: bind
         source: ${DATA_PATH}/logs
         target: /logs
+      - type: bind
+        source: ${DATA_PATH}/desktop-updates
+        target: /desktop-updates
     restart: unless-stopped
 
   bs-alloy:

--- a/docs/electron-desktop.md
+++ b/docs/electron-desktop.md
@@ -93,14 +93,20 @@ Current update feed is configured in `desktop/electron-builder.yml`:
 
 - `publish.provider = generic`
 - `publish.url = https://crm.revisbali.com/desktop-updates`
+- Angular SSR server explicitly serves this route from `/desktop-updates` directory.
 
 Required published files per release include:
 
 - Windows: `latest.yml` + `.exe` package artifacts
 - macOS: `latest-mac.yml` + `.zip` (and `.dmg` for manual install)
 
-For `generic` provider, upload the generated `desktop/dist/` release files to
-`https://crm.revisbali.com/desktop-updates` after each release.
+Desktop updates are published automatically by
+`.github/workflows/desktop-installers.yml` on every push to `main`.
+
+- CI stamps desktop version as `0.1.<workflow_run_number>` so installed apps can detect a newer version.
+- CI uploads update feed files directly to `${DATA_PATH}/desktop-updates` on VPS.
+- `bs-frontend` mounts `${DATA_PATH}/desktop-updates` to container path `/desktop-updates`.
+- SSR route `/desktop-updates/*` serves files from that mounted directory.
 
 ## Commands (Bun)
 
@@ -161,3 +167,13 @@ bun run dev
   - Windows signing is strongly recommended to reduce SmartScreen friction and update trust issues
 
 CI workflow: `.github/workflows/desktop-installers.yml`
+
+Required secrets for desktop feed publishing:
+
+- `VPS_HOST`
+- `VPS_USERNAME`
+- `SSH_PRIVATE_KEY`
+- `REPO_DIR`
+
+If your existing `deploy.yml` workflow is already working, these secrets are already present.
+No additional desktop-specific secret or env variable is required.

--- a/frontend/src/server.ts
+++ b/frontend/src/server.ts
@@ -32,6 +32,7 @@ import { dirname, join } from 'node:path';
 import { generateNonce } from './csp';
 
 const browserDistFolder = join(import.meta.dirname, '../browser');
+const desktopUpdatesFolder = process.env['DESKTOP_UPDATES_DIR'] || '/desktop-updates';
 
 const app = express();
 const angularApp = new AngularNodeAppEngine();
@@ -527,6 +528,39 @@ app.use((req, res, next) => {
 
   req.pipe(backendRequest);
 });
+
+/**
+ * Serve Electron desktop update feed files.
+ * This path is consumed by electron-updater generic provider.
+ */
+app.use(
+  '/desktop-updates',
+  express.static(desktopUpdatesFolder, {
+    index: false,
+    redirect: false,
+    fallthrough: false,
+    setHeaders: (res, filePath) => {
+      const normalizedPath = String(filePath || '').toLowerCase();
+      if (normalizedPath.endsWith('.yml') || normalizedPath.endsWith('.yaml')) {
+        res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+        res.setHeader('Pragma', 'no-cache');
+        res.setHeader('Expires', '0');
+        return;
+      }
+
+      if (
+        normalizedPath.endsWith('.exe') ||
+        normalizedPath.endsWith('.dmg') ||
+        normalizedPath.endsWith('.zip') ||
+        normalizedPath.endsWith('.blockmap')
+      ) {
+        res.setHeader('Cache-Control', 'public, max-age=3600');
+      }
+    },
+  }),
+);
+
+console.log(`[SSR Server] Desktop updates served from: ${desktopUpdatesFolder}`);
 
 /**
  * Serve static files from /browser


### PR DESCRIPTION
* [CRITICAL] CI workflow now publishes desktop updates on main push.
* Add version stamping for desktop apps to detect updates.
* Serve update files from mounted directory in SSR server.
* Update documentation to reflect new update feed process.