### PR TITLE
refactor(serializer): remove notification trigger from application up…

### DIFF
--- a/backend/api/serializers/doc_application_serializer.py
+++ b/backend/api/serializers/doc_application_serializer.py
@@ -413,7 +413,6 @@ class DocApplicationCreateUpdateSerializer(serializers.ModelSerializer):
         if has_auto_passport:
             self._auto_import_passport(application, user)
 
-        self._trigger_immediate_due_tomorrow_notification(application)
         return application
 
     def update(self, instance, validated_data):
@@ -462,18 +461,7 @@ class DocApplicationCreateUpdateSerializer(serializers.ModelSerializer):
                     updated_by=user,
                 )
 
-        self._trigger_immediate_due_tomorrow_notification(application)
         return application
-
-    def _trigger_immediate_due_tomorrow_notification(self, application):
-        from customer_applications.tasks import send_due_tomorrow_customer_notifications
-        from django.utils import timezone
-
-        send_due_tomorrow_customer_notifications(
-            now=timezone.now(),
-            application_ids=[application.id],
-            immediate=True,
-        )
 
     def _can_auto_import_passport(self, application) -> bool:
         """Check if passport can be auto-imported for this application."""


### PR DESCRIPTION
…date

* [CRITICAL] Simplify application update process by removing the immediate due tomorrow notification trigger.
* Update tests to ensure notifications are not called during application creation and update.
* Enhance code readability and maintainability.